### PR TITLE
Explore: save params in url (page & active datasets)

### DIFF
--- a/src/containers/explore/DatasetWidget/index.js
+++ b/src/containers/explore/DatasetWidget/index.js
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 import DatasetWidget from 'components/explore/DatasetWidget';
-import { toggleDatasetActive } from 'redactions/explore';
+import { toggleDatasetActive, setUrlParams } from 'redactions/explore';
 
 const mapStateToProps = null;
 
 const mapDispatchToProps = dispatch => ({
   toggleDatasetActive: (id) => {
     dispatch(toggleDatasetActive(id));
+    dispatch(setUrlParams());
   }
 });
 

--- a/src/containers/pages/Explore/index.js
+++ b/src/containers/pages/Explore/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Explore from 'components/pages/Explore';
-import { getDatasets, setDatasetsPage } from 'redactions/explore';
+import { getDatasets, setDatasetsPage, setUrlParams } from 'redactions/explore';
 import getpaginatedDatasets from 'selectors/explore/datasetsPaginatedExplore';
 
 const mapStateToProps = state => ({
@@ -14,6 +14,7 @@ const mapDispatchToProps = dispatch => ({
   },
   setDatasetsPage: (page) => {
     dispatch(setDatasetsPage(page));
+    dispatch(setUrlParams());
   }
 });
 

--- a/src/redactions/explore.js
+++ b/src/redactions/explore.js
@@ -1,6 +1,7 @@
 /* global config */
 import 'whatwg-fetch';
 import find from 'lodash/find';
+import { replace } from 'react-router-redux';
 
 /**
  * CONSTANTS
@@ -58,17 +59,8 @@ export default function (state = initialState, action) {
     }
 
     case SET_DATASETS_ACTIVE: {
-      const active = state.datasets.active.slice(0);
-      const index = active.indexOf(action.payload);
-      // Toggle the active dataset
-      if (index !== -1) {
-        active.splice(index, 1);
-      } else {
-        active.push(action.payload);
-      }
-
       const datasets = Object.assign({}, state.datasets, {
-        active
+        active: action.payload
       });
 
       return Object.assign({}, state, { datasets });
@@ -149,9 +141,47 @@ export function setDatasetsPage(page) {
   };
 }
 
-export function toggleDatasetActive(id) {
+export function setDatasetsActive(active) {
   return {
     type: SET_DATASETS_ACTIVE,
-    payload: id
+    payload: active
+  };
+}
+
+
+export function toggleDatasetActive(id) {
+  return (dispatch, state) => {
+    const { explore } = state();
+    const active = explore.datasets.active.slice(0);
+    const index = active.indexOf(id);
+
+    // Toggle the active dataset
+    if (index !== -1) {
+      active.splice(index, 1);
+    } else {
+      active.push(id);
+    }
+
+    dispatch({
+      type: SET_DATASETS_ACTIVE,
+      payload: active
+    });
+  };
+}
+
+// Let's use {replace} instead of {push}, that's how we will allow users to
+// go away from the current page
+export function setUrlParams() {
+  return (dispatch, state) => {
+    const { explore } = state();
+    const { active, page } = explore.datasets;
+    const locationDescriptor = {
+      pathname: '/explore',
+      query: {
+        active: active.length ? active.join(',') : undefined,
+        page
+      }
+    };
+    dispatch(replace(locationDescriptor));
   };
 }

--- a/src/redactions/routes.js
+++ b/src/redactions/routes.js
@@ -1,0 +1,32 @@
+import { dispatch } from 'main';
+import { setDatasetsPage, setDatasetsActive } from 'redactions/explore';
+
+export function onEnterExploreUrlParams(nextState, replace, done) {
+  const nextLocation = nextState.location;
+  if (nextLocation.query.page) {
+    dispatch(setDatasetsPage(+nextLocation.query.page));
+  }
+
+  if (nextLocation.query.active) {
+    const active = nextLocation.query.active.split(',');
+    dispatch(setDatasetsActive(active));
+  }
+
+  done();
+}
+
+export function onChangeExploreUrlParams(prevState, nextState, replace, done) {
+  const prevLocation = prevState.location;
+  const nextLocation = nextState.location;
+  /* PAGE */
+  if (prevLocation.query.page !== nextLocation.query.page) {
+    dispatch(setDatasetsPage(+nextLocation.query.page));
+  }
+
+  if (nextLocation.query.active) {
+    const active = nextLocation.query.active.split(',');
+    dispatch(setDatasetsActive(active));
+  }
+
+  done();
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { IndexRoute, Router, Route } from 'react-router';
+import { onEnterExploreUrlParams, onChangeExploreUrlParams } from 'redactions/routes';
 
 // Components
 import App from './App';
@@ -15,7 +16,7 @@ function Routes(props) {
         <IndexRoute component={Home} />
 
         <Route path="explore">
-          <IndexRoute component={Explore} />
+          <IndexRoute component={Explore} onEnter={onEnterExploreUrlParams} onChange={onChangeExploreUrlParams} />
         </Route>
 
         <Route path="planet-pulse">


### PR DESCRIPTION
This PR adds:
- On each change we save the params in the URL, for the moment we are saving `page` and `active` datasets. We should add more when it's necessary (grid and filters)